### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/ResumeFromState.yaml
+++ b/ResumeFromState.yaml
@@ -58,7 +58,7 @@ Resources:
               event.Message = event.Message;
               callback(null, event);
           };
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
   SecondLambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -72,7 +72,7 @@ Resources:
               }
               callback(null, event);
           };
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
   ResumeFromStateExample:
     Type: AWS::StepFunctions::StateMachine
     Properties:


### PR DESCRIPTION
CloudFormation templates in aws-sfn-resume-from-any-state have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.